### PR TITLE
Added get_current_auctions function

### DIFF
--- a/bvapi.py
+++ b/bvapi.py
@@ -65,6 +65,19 @@ class bva_api:
             return response.json()['message']
         return True
 
+    # get_current_auctions retrieves all current auctions
+    # @param page: the page of the auctions list. Defaults to 1.
+    # @param pagesize: the size of the auction list page. Defaults to 50.
+    def get_current_auctions(self, page=1, page_size=50):
+        url = self.base_url + 'ext123/auctions/bycurrent/paged'
+        payload = {'page': page, 'pageSize': page_size}
+        response = requests.get(url, headers=self.request_headers, params=payload)
+
+        if response.ok:
+            return response.json()
+        else:
+            return response.json()['message']
+
     # get_auction retrieves auction details
     # @param auction_id: the id of the auction
     def get_auction(self, auction_id):


### PR DESCRIPTION
Added a get_current_auctions function that will retrieve a list of all current auctions. Since the results are paged there are 2 parameters, `page` and `page_size` which default to `1` and `50`, respectively.